### PR TITLE
Use publicnode rpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ Alternatively you can use a private key directly with the `--privatekey` option,
 
 Ethereal supports all main Ethereum networks  It auto-detects the network by querying the connected node for the network ID.  The connection should be geth-compatible, so either geth itself or parity with the `--geth` flag to enable geth compatibility mode.  The connection could be a local node or a network service such as Infura.
 
-Ethereal contains default connections via Infura to most major networks that can be defined by the `--network` argument.  Supported neworks are mainnet, sepolia and holesky.  Alternatively a connection to a custom node can be created using the `--connection` argument.  For example a local IPC node might use `--connection=/home/ethereum/.ethereum/geth.ipc` or `--connection=http://localhost:8545/`
-
-**The Infura key for Ethereal is shared among all users.  If you are going to carry out a lot of queries of chain data please either use a local node or your own Infura account.**
+Ethereal contains default connections via [publicnode](https://ethereum.publicnode.com/) to most major networks that can be defined by the `--network` argument.  Supported neworks are mainnet, sepolia and holesky.  Alternatively a connection to a custom node can be created using the `--connection` argument.  For example a local IPC node might use `--connection=/home/ethereum/.ethereum/geth.ipc` or `--connection=http://localhost:8545/`
 
 ### Configuration file
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,11 +195,11 @@ func connectionAddress(_ context.Context) (string, error) {
 
 	switch strings.ToLower(viper.GetString("network")) {
 	case "mainnet":
-		return "https://mainnet.infura.io/v3/831a5442dc2e4536a9f8dee4ea1707a6", nil
+		return "https://ethereum-rpc.publicnode.com", nil
 	case "sepolia":
-		return "https://sepolia.infura.io/v3/831a5442dc2e4536a9f8dee4ea1707a6", nil
+		return "https://ethereum-sepolia-rpc.publicnode.com", nil
 	case "holesky":
-		return "https://holesky.infura.io/v3/831a5442dc2e4536a9f8dee4ea1707a6", nil
+		return "https://ethereum-holesky-rpc.publicnode.com", nil
 	default:
 		return "", fmt.Errorf("unknown network %s", viper.GetString("network"))
 	}

--- a/util/funcparser/goerli_test.go
+++ b/util/funcparser/goerli_test.go
@@ -142,7 +142,7 @@ func TestGoerli(t *testing.T) {
 	}
 
 	// Connect to goerli
-	conn, err := ethclient.Dial("https://goerli.infura.io/v3/831a5442dc2e4536a9f8dee4ea1707a6")
+	conn, err := ethclient.Dial("https://ethereum-sepolia-rpc.publicnode.com")
 	require.Nil(t, err, "failed to connect to goerli")
 
 	json, err := os.ReadFile("Tester.json")


### PR DESCRIPTION
The old infra rpc is failed, shall we switch to public rpcs, publicnode rpcs is quite stable.